### PR TITLE
Fix DC-999 Query cache key can be incorrectly generated

### DIFF
--- a/lib/Doctrine/Query/Abstract.php
+++ b/lib/Doctrine/Query/Abstract.php
@@ -891,7 +891,8 @@ abstract class Doctrine_Query_Abstract
     public function calculateQueryCacheHash()
     {
         $dql = $this->getDql();
-        $hash = md5($dql . var_export($this->_pendingJoinConditions, true) . 'DOCTRINE_QUERY_CACHE_SALT');
+        $conn = $this->getConnection();
+        $hash = md5($dql . $conn->getOption('dsn') . var_export($this->_pendingJoinConditions, true) . 'DOCTRINE_QUERY_CACHE_SALT');
         return $hash;
     }
 


### PR DESCRIPTION
If you run two versions of a site on one server (e.g. staging and
prod), and one has an updated schema, queries without explicit columns
cause a fatal error due to query caching.

This fixes it by including the DSN in the cache key.

Reference: http://www.doctrine-project.org/jira/browse/DC-999
