### PR TITLE
Remove preg_replace /e for PHP5.5 (from e-venement)

### DIFF
--- a/lib/Doctrine/Adapter/Statement/Oracle.php
+++ b/lib/Doctrine/Adapter/Statement/Oracle.php
@@ -583,7 +583,7 @@ class Doctrine_Adapter_Statement_Oracle implements Doctrine_Adapter_Statement_In
         }
         $bind_index = 1;
         // Replace ? bind-placeholders with :oci_b_var_ variables
-        $query = preg_replace("/(\?)/e", '":oci_b_var_". $bind_index++' , $query);
+        $query = preg_replace_callback("/(\?)/", function($m) { return ":oci_b_var_". $bind_index++; } , $query);
 
         $this->statement =  @oci_parse($this->connection, $query);
 

--- a/lib/Doctrine/Connection/Mssql.php
+++ b/lib/Doctrine/Connection/Mssql.php
@@ -189,7 +189,7 @@ class Doctrine_Connection_Mssql extends Doctrine_Connection_Common
         $tokens = preg_split('/,/', $parsed);
 
         for ($i = 0, $iMax = count($tokens); $i < $iMax; $i++) {
-            $tokens[$i] = trim(preg_replace('/##(\d+)##/e', "\$chunks[\\1]", $tokens[$i]));
+            $tokens[$i] = trim(preg_replace_callback('/##(\d+)##/', function($m) { return $chunks[$m[1]]; }, $tokens[$i]));
         }
 
         return $tokens;


### PR DESCRIPTION
> correction d'autres "preg_replace /e" qui n'avaient pas été corrigés pour PHP-5.5

From http://www.e-venement.org/2013/12/06/e-venement-forke-symfony1/
