### PR TITLE
Merge and toArray should both be called with the same $deep param

### DIFF
--- a/lib/Doctrine/AuditLog/Listener.php
+++ b/lib/Doctrine/AuditLog/Listener.php
@@ -79,7 +79,7 @@ class Doctrine_AuditLog_Listener extends Doctrine_Record_Listener
 
             $record  = $event->getInvoker();
             $version = new $class();
-            $version->merge($record->toArray(), false);
+            $version->merge($record->toArray(false), false);
             $version->save();
         }
     }
@@ -133,7 +133,7 @@ class Doctrine_AuditLog_Listener extends Doctrine_Record_Listener
             $record->set($name, $this->_getNextVersion($record));
 
             $version = new $class();
-            $version->merge($record->toArray(), false);
+            $version->merge($record->toArray(false), false);
             $version->save();
         }
     }


### PR DESCRIPTION
Merge() is called with deep=false, so toArray() can (and should) also be called with $deep=false. This was resulting in some weird behaviour in our codebase (records not being saved properly). 
