### PR TITLE
Fix dynamic property accessor syntax to be compatible with PHP7

### DIFF
--- a/lib/Doctrine/Collection.php
+++ b/lib/Doctrine/Collection.php
@@ -472,7 +472,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
             $relations = $this->relation['table']->getRelations();
             foreach ($relations as $relation) {
                 if ($this->relation['class'] == $relation['localTable']->getOption('name') && $relation->getLocal() == $this->relation->getForeignFieldName()) {
-                    $record->$relation['alias'] = $this->reference;
+                    $record->{$relation['alias']} = $this->reference;
                     break;
                 }
             }

--- a/lib/Doctrine/Query/Abstract.php
+++ b/lib/Doctrine/Query/Abstract.php
@@ -1135,8 +1135,8 @@ abstract class Doctrine_Query_Abstract
                 $params = array('component' => $component, 'alias' => $alias);
                 $event = new Doctrine_Event($record, $callback['const'], $this, $params);
 
-                $record->$callback['callback']($event);
-                $table->getRecordListener()->$callback['callback']($event);
+                $record->{$callback['callback']}($event);
+                $table->getRecordListener()->{$callback['callback']}($event);
             }
         }
 


### PR DESCRIPTION
During a few tests with our application I encountered a few weird errors in Doctrine. After some codediving I found some syntax constructs incompatible with PHP7. Adding a few braces fixes the problem :).

For more info see:
http://php.net/manual/en/migration70.incompatible.php