### PR TITLE
Remove preg_replace /e for PHP5.5: increment bind_index in preg_replace_callback

### DIFF
--- a/lib/Doctrine/Adapter/Statement/Oracle.php
+++ b/lib/Doctrine/Adapter/Statement/Oracle.php
@@ -583,7 +583,7 @@ class Doctrine_Adapter_Statement_Oracle implements Doctrine_Adapter_Statement_In
         }
         $bind_index = 1;
         // Replace ? bind-placeholders with :oci_b_var_ variables
-        $query = preg_replace_callback("/(\?)/", function($m) { return ":oci_b_var_". $bind_index++; } , $query);
+        $query = preg_replace_callback("/(\?)/", function($m) use(&$bind_index) { return ":oci_b_var_". $bind_index++; } , $query);
 
         $this->statement =  @oci_parse($this->connection, $query);
 


### PR DESCRIPTION
As promised here a proper PR for fixing preg_replace_callback with oracle