### PR TITLE
Do not close cursors while using ON_DEMAND hydration

### DIFF
--- a/lib/Doctrine/Hydrator/Graph.php
+++ b/lib/Doctrine/Hydrator/Graph.php
@@ -105,7 +105,6 @@ abstract class Doctrine_Hydrator_Graph extends Doctrine_Hydrator_Abstract
             } else {
                 $data = $stmt->fetch(Doctrine_Core::FETCH_ASSOC);
                 if ( ! $data) {
-                    $stmt->closeCursor();
                     return $result;
                 }
             }
@@ -136,7 +135,6 @@ abstract class Doctrine_Hydrator_Graph extends Doctrine_Hydrator_Abstract
                 } else if ($activeRootIdentifier != $id[$rootAlias]) {
                     // first row for the next record
                     $this->_priorRow = $data;
-                    $stmt->closeCursor();
                     return $result;
                 }
             }


### PR DESCRIPTION
The bug appeared in commit 150e1e4 

The only one `closeCursor` call left from commit 150e1e4, because not an ON_DEMAND hydration case.