### PR TITLE
If you make a fix for Oracle connection only do it ONLY for Oracle!

### DIFF
--- a/lib/Doctrine/Connection/Statement.php
+++ b/lib/Doctrine/Connection/Statement.php
@@ -271,9 +271,11 @@ class Doctrine_Connection_Statement implements Doctrine_Adapter_Statement_Interf
             $this->_conn->getListener()->postStmtExecute($event);
 
             //fix a possible "ORA-01000: maximum open cursors exceeded" when many non-SELECTs are executed and the profiling is enabled
-            $queryBeginningSubstring = strtoupper(substr(ltrim($this->_stmt->queryString), 0, 6));
-            if ($queryBeginningSubstring != 'SELECT' && substr($queryBeginningSubstring, 0, 4) != 'WITH' ){
-                $this->closeCursor();
+            if ('Oracle' == $this->getConnection()->getDriverName()) {
+                $queryBeginningSubstring = strtoupper(substr(ltrim($this->_stmt->queryString), 0, 6));
+                if ($queryBeginningSubstring != 'SELECT' && substr($queryBeginningSubstring, 0, 4) != 'WITH' ){
+                    $this->closeCursor();
+                }
             }
 
             return $result;


### PR DESCRIPTION
Such a fix broke mysql queries which contained spaces before 'SELECT' (common situation when you format your code or make your query substring by substring).