### PR TITLE
Geographical сoordinate accuracy fix

### DIFF
--- a/lib/Doctrine/Template/Geographical.php
+++ b/lib/Doctrine/Template/Geographical.php
@@ -42,11 +42,11 @@ class Doctrine_Template_Geographical extends Doctrine_Template
     protected $_options = array('latitude' =>  array('name'     =>  'latitude',
                                                      'type'     =>  'decimal',
                                                      'size'     =>  10,
-                                                     'options'  =>  array('scale'=>6)),
+                                                     'options'  =>  array('scale' => 6)),
                                 'longitude' => array('name'     =>  'longitude',
                                                      'type'     =>  'decimal',
                                                      'size'     =>  10,
-                                                     'options'  =>  array('scale'=>6)));
+                                                     'options'  =>  array('scale' => 6)));
 
     /**
      * Set table definition for Geographical behavior

--- a/lib/Doctrine/Template/Geographical.php
+++ b/lib/Doctrine/Template/Geographical.php
@@ -40,13 +40,13 @@ class Doctrine_Template_Geographical extends Doctrine_Template
      * @var string
      */
     protected $_options = array('latitude' =>  array('name'     =>  'latitude',
-                                                     'type'     =>  'double',
-                                                     'size'     =>  null,
-                                                     'options'  =>  array()),
+                                                     'type'     =>  'decimal',
+                                                     'size'     =>  10,
+                                                     'options'  =>  array('scale'=>6)),
                                 'longitude' => array('name'     =>  'longitude',
-                                                     'type'     =>  'double',
-                                                     'size'     =>  null,
-                                                     'options'  =>  array()));
+                                                     'type'     =>  'decimal',
+                                                     'size'     =>  10,
+                                                     'options'  =>  array('scale'=>6)));
 
     /**
      * Set table definition for Geographical behavior


### PR DESCRIPTION
Nulls will generate tables with DOUBLE(18,2) which is not good for coordinates (math issues and wrong size). Better values for latitude and longitude is DECIMAL(10,6) this will store with accuracy down to about 1/6th of an inch at the equator.