### PR TITLE
Use correct case for calls to ReflectionClass::isSubclassOf

### DIFF
--- a/lib/Doctrine/Cli.php
+++ b/lib/Doctrine/Cli.php
@@ -359,7 +359,7 @@ class Doctrine_Cli
     protected function classIsTask($className)
     {
         $reflectionClass = new ReflectionClass($className);
-        return (bool) $reflectionClass->isSubClassOf(self::TASK_BASE_CLASS);
+        return (bool) $reflectionClass->isSubclassOf(self::TASK_BASE_CLASS);
     }
 
     /**

--- a/lib/Doctrine/Core.php
+++ b/lib/Doctrine/Core.php
@@ -815,7 +815,7 @@ class Doctrine_Core
             // Skip the following classes
             // - abstract classes
             // - not a subclass of Doctrine_Record
-            if ( ! $class->isAbstract() && $class->isSubClassOf('Doctrine_Record')) {
+            if ( ! $class->isAbstract() && $class->isSubclassOf('Doctrine_Record')) {
 
                 return true;
             }

--- a/lib/Doctrine/Table.php
+++ b/lib/Doctrine/Table.php
@@ -356,7 +356,7 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable, Seriali
             }
             $ref = new ReflectionClass($parent);
 
-            if ($ref->isAbstract() || ! $class->isSubClassOf($parent)) {
+            if ($ref->isAbstract() || ! $class->isSubclassOf($parent)) {
                 continue;
             }
             $parentTable = $this->_conn->getTable($parent);

--- a/tests/Import/BuilderTestCase.php
+++ b/tests/Import/BuilderTestCase.php
@@ -50,36 +50,36 @@ class Doctrine_Import_Builder_TestCase extends Doctrine_UnitTestCase
         $schemaTestInheritanceChild1Table = new ReflectionClass('SchemaTestInheritanceChild1Table');
         $schemaTestInheritanceChild2Table = new ReflectionClass('SchemaTestInheritanceChild2Table');
 
-        $this->assertTrue($schemaTestInheritanceParent->isSubClassOf('Doctrine_Record'));
-        $this->assertTrue($schemaTestInheritanceParent->isSubClassOf('BaseSchemaTestInheritanceParent'));
-        $this->assertTrue($schemaTestInheritanceParent->isSubClassOf('PackageSchemaTestInheritanceParent'));
-        $this->assertTrue($schemaTestInheritanceChild1->isSubClassOf('BaseSchemaTestInheritanceChild1'));
-        $this->assertTrue($schemaTestInheritanceChild2->isSubClassOf('BaseSchemaTestInheritanceChild2'));
+        $this->assertTrue($schemaTestInheritanceParent->isSubclassOf('Doctrine_Record'));
+        $this->assertTrue($schemaTestInheritanceParent->isSubclassOf('BaseSchemaTestInheritanceParent'));
+        $this->assertTrue($schemaTestInheritanceParent->isSubclassOf('PackageSchemaTestInheritanceParent'));
+        $this->assertTrue($schemaTestInheritanceChild1->isSubclassOf('BaseSchemaTestInheritanceChild1'));
+        $this->assertTrue($schemaTestInheritanceChild2->isSubclassOf('BaseSchemaTestInheritanceChild2'));
         
-        $this->assertTrue($schemaTestInheritanceChild1->isSubClassOf('SchemaTestInheritanceParent'));
-        $this->assertTrue($schemaTestInheritanceChild1->isSubClassOf('BaseSchemaTestInheritanceParent'));
+        $this->assertTrue($schemaTestInheritanceChild1->isSubclassOf('SchemaTestInheritanceParent'));
+        $this->assertTrue($schemaTestInheritanceChild1->isSubclassOf('BaseSchemaTestInheritanceParent'));
         
-        $this->assertTrue($schemaTestInheritanceChild2->isSubClassOf('SchemaTestInheritanceParent'));
-        $this->assertTrue($schemaTestInheritanceChild2->isSubClassOf('BaseSchemaTestInheritanceParent'));
-        $this->assertTrue($schemaTestInheritanceChild2->isSubClassOf('SchemaTestInheritanceChild1'));
-        $this->assertTrue($schemaTestInheritanceChild2->isSubClassOf('BaseSchemaTestInheritanceChild1'));
-        $this->assertTrue($schemaTestInheritanceChild2->isSubClassOf('PackageSchemaTestInheritanceParent'));
+        $this->assertTrue($schemaTestInheritanceChild2->isSubclassOf('SchemaTestInheritanceParent'));
+        $this->assertTrue($schemaTestInheritanceChild2->isSubclassOf('BaseSchemaTestInheritanceParent'));
+        $this->assertTrue($schemaTestInheritanceChild2->isSubclassOf('SchemaTestInheritanceChild1'));
+        $this->assertTrue($schemaTestInheritanceChild2->isSubclassOf('BaseSchemaTestInheritanceChild1'));
+        $this->assertTrue($schemaTestInheritanceChild2->isSubclassOf('PackageSchemaTestInheritanceParent'));
 
-        $this->assertTrue($schemaTestInheritanceParentTable->isSubClassOf('Doctrine_Table'));
-        $this->assertTrue($schemaTestInheritanceChild1Table->isSubClassOf('SchemaTestInheritanceParentTable'));
-        $this->assertTrue($schemaTestInheritanceChild1Table->isSubClassOf('PackageSchemaTestInheritanceParentTable'));
+        $this->assertTrue($schemaTestInheritanceParentTable->isSubclassOf('Doctrine_Table'));
+        $this->assertTrue($schemaTestInheritanceChild1Table->isSubclassOf('SchemaTestInheritanceParentTable'));
+        $this->assertTrue($schemaTestInheritanceChild1Table->isSubclassOf('PackageSchemaTestInheritanceParentTable'));
 
-        $this->assertTrue($schemaTestInheritanceChild2Table->isSubClassOf('SchemaTestInheritanceParentTable'));
-        $this->assertTrue($schemaTestInheritanceChild2Table->isSubClassOf('PackageSchemaTestInheritanceParentTable'));
-        $this->assertTrue($schemaTestInheritanceChild2Table->isSubClassOf('SchemaTestInheritanceChild1Table'));
-        $this->assertTrue($schemaTestInheritanceChild2Table->isSubClassOf('PackageSchemaTestInheritanceChild1Table'));
+        $this->assertTrue($schemaTestInheritanceChild2Table->isSubclassOf('SchemaTestInheritanceParentTable'));
+        $this->assertTrue($schemaTestInheritanceChild2Table->isSubclassOf('PackageSchemaTestInheritanceParentTable'));
+        $this->assertTrue($schemaTestInheritanceChild2Table->isSubclassOf('SchemaTestInheritanceChild1Table'));
+        $this->assertTrue($schemaTestInheritanceChild2Table->isSubclassOf('PackageSchemaTestInheritanceChild1Table'));
 
         # Simple Inheritance
         $schemaTestSimpleInheritanceParent = new ReflectionClass('SchemaTestSimpleInheritanceParent');
         $schemaTestSimpleInheritanceChild = new ReflectionClass('SchemaTestSimpleInheritanceChild');
 
         $this->assertTrue($schemaTestSimpleInheritanceParent->hasMethod('setTableDefinition'));
-        $this->assertTrue($schemaTestSimpleInheritanceChild->isSubClassOf('SchemaTestSimpleInheritanceParent'));
+        $this->assertTrue($schemaTestSimpleInheritanceChild->isSubclassOf('SchemaTestSimpleInheritanceParent'));
 
         # Class Table Inheritance
         $schemaTestClassTableInheritanceParent = new ReflectionClass('SchemaTestClassTableInheritanceParent');


### PR DESCRIPTION
PHP is case insensitive for method calls, but we may as well do this
correctly.
Fixes lexpress/doctrine1#40