### PR TITLE
PHP 7.2: count()

### DIFF
--- a/lib/Doctrine/Query/Abstract.php
+++ b/lib/Doctrine/Query/Abstract.php
@@ -1384,7 +1384,7 @@ abstract class Doctrine_Query_Abstract
     public function andWhereIn($expr, $params = array(), $not = false)
     {
         // if there's no params, return (else we'll get a WHERE IN (), invalid SQL)
-        if (isset($params) and (count($params) == 0)) {
+        if (isset($params) and is_array($params) and (count($params) == 0)) {
             return $this;
         }
 


### PR DESCRIPTION
fix - Parameter must be an array or an object that implements Countable