### PR TITLE
Skip options charset and collation for field validation

### DIFF
--- a/lib/Doctrine/Table.php
+++ b/lib/Doctrine/Table.php
@@ -2655,6 +2655,8 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable, Seriali
                     || $name == 'fixed'
                     || $name == 'comment'
                     || $name == 'alias'
+                    || $name == 'charset'
+                    || $name == 'collation'
                     || $name == 'extra') {
                 continue;
             }


### PR DESCRIPTION
Doctrine scans field options such as notnull for applying applicable validators prior to persisting a field value. For options charset and collation there exist no such validators, hence an exception is thrown when persisting a field using any of these options. This fix adds charset and collation to the list of ignored options.