### PR TITLE
Fix more than one record generator initialisation on same php process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,8 @@ matrix:
     - php: nightly
     - php: hhvm
 
+before_script:
+    - composer install
+
 script:
   - php -dshort_open_tag=Off -dmagic_quotes_gpc=Off tests/index.php

--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,8 @@
     },
     "autoload": {
         "psr-0": { "Doctrine_": "lib/" }
+    },
+    "autoload-dev": {
+        "psr-4": { "": "tests/autoloaded/" }
     }
 }

--- a/lib/Doctrine/Event.php
+++ b/lib/Doctrine/Event.php
@@ -68,6 +68,7 @@ class Doctrine_Event
     const RECORD_DQL_SELECT  = 28;
     const RECORD_DQL_UPDATE  = 29;
     const RECORD_VALIDATE    = 30;
+    const RECORD_POST_SETUP  = 31;
 
     /**
      * @var mixed $_nextSequence        the sequence of the next event that will be created

--- a/lib/Doctrine/Record.php
+++ b/lib/Doctrine/Record.php
@@ -601,6 +601,13 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
     { }
 
     /**
+     * Empty template method to provide Record classes with the ability to alter setup
+     * after it runs
+     */
+    public function postSetUp($event)
+    { }
+
+    /**
      * Get the record error stack as a human readable string.
      * Useful for outputting errors to user via web browser
      *

--- a/lib/Doctrine/Record/Generator.php
+++ b/lib/Doctrine/Record/Generator.php
@@ -160,12 +160,6 @@ abstract class Doctrine_Record_Generator extends Doctrine_Record_Abstract
             $this->_options['tableName'] = str_replace('%TABLE%', $ownerTableName, $tableName);
         }
 
-        // check that class doesn't exist (otherwise we cannot create it)
-        if ($this->_options['generateFiles'] === false && class_exists($this->_options['className'])) {
-            $this->_table = Doctrine_Core::getTable($this->_options['className']);
-            return false;
-        }
-
         $this->buildTable();
 
         $fk = $this->buildForeignKeys($this->_options['table']);
@@ -461,7 +455,9 @@ abstract class Doctrine_Record_Generator extends Doctrine_Record_Abstract
             } else {
                 throw new Doctrine_Record_Exception('If you wish to generate files then you must specify the path to generate the files in.');
             }
-        } else {
+        } elseif (!class_exists($definition['className'])) {
+            // The class is not defined then we can load the definition.
+
             $def = $builder->buildDefinition($definition);
 
             eval($def);

--- a/lib/Doctrine/Search.php
+++ b/lib/Doctrine/Search.php
@@ -311,11 +311,6 @@ class Doctrine_Search extends Doctrine_Record_Generator
 
         $className = $this->getOption('className');
 
-        $autoLoad = (bool) ($this->_options['generateFiles']);
-        if (class_exists($className, $autoLoad)) {
-            return false;
-        }
-
         // move any columns currently in the primary key to the end
         // So that 'keyword' is the first field in the table
         $previousIdentifier = array();

--- a/lib/Doctrine/Table.php
+++ b/lib/Doctrine/Table.php
@@ -268,6 +268,10 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable, Seriali
             if ($this->isTree()) {
                 $this->getTree()->setUp();
             }
+
+            $event = new Doctrine_Event($this->record, Doctrine_Event::RECORD_POST_SETUP);
+
+            $this->record->postSetUp($event);
         } else {
             if ( ! isset($this->_options['tableName'])) {
                 $this->setTableName(Doctrine_Inflector::tableize($this->_options['name']));
@@ -3056,6 +3060,10 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable, Seriali
         if ($this->isTree()) {
             $this->getTree()->setUp();
         }
+
+        $event = new Doctrine_Event($this->record, Doctrine_Event::RECORD_POST_SETUP);
+
+        $this->record->postSetUp($event);
 
         $this->_filters[]  = new Doctrine_Record_Filter_Standard();
         if ($this->getAttribute(Doctrine_Core::ATTR_USE_TABLE_REPOSITORY)) {

--- a/tests/Record/GeneratorTestCase.php
+++ b/tests/Record/GeneratorTestCase.php
@@ -55,6 +55,22 @@ class Doctrine_Record_Generator_TestCase extends Doctrine_UnitTestCase
             $this->fail($e->getMessage());
         }
     }
+
+    public function testGeneratorModelAutoload()
+    {
+        Doctrine_Manager::connection('sqlite::memory:', 'test_tmp_conn', false);
+        Doctrine_Manager::getInstance()->bindComponent('I18nGeneratorModelAutoload', 'test_tmp_conn');
+        Doctrine_Core::createTablesFromArray(array('I18nGeneratorModelAutoload'));
+
+        try {
+            $record = new I18nGeneratorModelAutoload();
+            $record->Translation['EN']->title = 'en test';
+
+            $this->fail('The generated record class is autoloadable then it must be used.');
+        } catch (LogicException $e) {
+            $this->assertEqual('This record is expected to be instanciated as generateFiles option on record generator is false and it is autoloadable.', $e->getMessage());
+        }
+    }
 }
 
 class I18nGeneratorComponentBinding extends Doctrine_Record
@@ -69,4 +85,8 @@ class I18nGeneratorComponentBinding extends Doctrine_Record
     {
         $this->actAs('I18n', array('fields' => array('title')));
     }
+}
+
+class I18nGeneratorModelAutoload extends I18nGeneratorComponentBinding
+{
 }

--- a/tests/TableTestCase.php
+++ b/tests/TableTestCase.php
@@ -36,6 +36,7 @@ class Doctrine_Table_TestCase extends Doctrine_UnitTestCase
     public function prepareTables()
     {
         $this->tables[] = 'FieldNameTest';
+        $this->tables[] = 'I18nFilterTest';
         parent::prepareTables();
     }
 
@@ -55,6 +56,31 @@ class Doctrine_Table_TestCase extends Doctrine_UnitTestCase
         $unserializedTable->initializeFromCache($this->objTable->getConnection());
 
         $this->assertEqual($table->getColumns(), $unserializedTable->getColumns());
+    }
+
+    public function testSerializeWithI18nFilter()
+    {
+        $table = $this->conn->getTable('I18nFilterTest');
+
+        $record = $table->create();
+        $record['name'] = 'foo';
+        $this->assertEqual('foo', $record['name']);
+
+        // Test the I18nFilterTest record that include the second filter.
+        $this->assertTrue(in_array('I18nFilterTestFilter', array_map('get_class', $table->getFilters())));
+        $expectedFilterNames = array_map('get_class', $table->getFilters());
+
+        $serializedTable = serialize($table);
+
+        $unserializedTable = unserialize($serializedTable);
+        $unserializedTable->initializeFromCache($this->conn);
+
+        $record = $unserializedTable->create();
+
+        $this->assertEqual($expectedFilterNames, array_map('get_class', $unserializedTable->getFilters()));
+
+        $record['name'] = 'foo';
+        $this->assertEqual('foo', $record['name']);
     }
 
     public function testFieldConversion()

--- a/tests/autoloaded/I18nGeneratorModelAutoloadTranslation.php
+++ b/tests/autoloaded/I18nGeneratorModelAutoloadTranslation.php
@@ -1,0 +1,9 @@
+<?php
+
+class I18nGeneratorModelAutoloadTranslation extends Doctrine_Record
+{
+    public function __construct()
+    {
+        throw new LogicException('This record is expected to be instanciated as generateFiles option on record generator is false and it is autoloadable.');
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,7 +12,7 @@ ini_set('date.timezone', 'GMT+0');
 
 define('DOCTRINE_DIR', $_SERVER['DOCTRINE_DIR']);
 
-require_once(DOCTRINE_DIR . '/lib/Doctrine/Core.php');
+require_once DOCTRINE_DIR.'/vendor/autoload.php';
 
 spl_autoload_register(array('Doctrine_Core', 'autoload'));
 spl_autoload_register(array('Doctrine_Core', 'modelsAutoload'));

--- a/tests/models/I18nFilterTest.php
+++ b/tests/models/I18nFilterTest.php
@@ -1,0 +1,58 @@
+<?php
+
+class I18nFilterTest extends Doctrine_Record
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function setTableDefinition()
+    {
+        $this->hasColumn('name', 'string', 200);
+        $this->hasColumn('title', 'string', 200);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        $this->actAs('I18n', array('fields' => array('name', 'title')));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function postSetUp($event)
+    {
+        parent::postSetUp($event);
+
+        $table = $this->getTable();
+
+        if ($table->hasRelation('Translation')) {
+            $table->unshiftFilter(new I18nFilterTestFilter());
+        }
+    }
+}
+
+class I18nFilterTestFilter extends Doctrine_Record_Filter
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function filterSet(Doctrine_Record $record, $name, $value)
+    {
+        return $record['Translation']['en'][$name] = $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function filterGet(Doctrine_Record $record, $name)
+    {
+        $trans = $record['Translation'];
+
+        if (isset($trans['en'])) {
+            return $trans['en'][$name];
+        }
+    }
+}


### PR DESCRIPTION
What provides this patch?
--------------

- Be able to use record generator for more than one connection the main usage is for a replica (e.g. master/slave, `sfDoctrineMasterSlavePlugin`).

How the bug is going to be patched?
-----------------------------------------

- Add test to avoid BC breaks when the class record can be autoloaded
- Add test for table serialization with I18n behavior and its record filter
- Add record post setUp event. This is required to define filters that depend on a specific relationship (e.g. `sfDoctrineRecordI18nFilter`)
- Fix table serialization for record filters.

Side note
-----

- The `sfDoctrinePlugin` need to be fixed in consequences.
- The current directory to run tests must be fixed to `tests`.

cc @j0k3r @GromNaN