### PR TITLE
Fix and add test for getConnectionDrivers method

### DIFF
--- a/lib/Doctrine/Manager.php
+++ b/lib/Doctrine/Manager.php
@@ -819,7 +819,7 @@ class Doctrine_Manager extends Doctrine_Configurable implements Countable, Itera
      */
     public function getConnectionDrivers()
     {
-        return $this->_connectionsDrivers;
+        return $this->_connectionDrivers;
     }
 
     /**

--- a/tests/ManagerTestCase.php
+++ b/tests/ManagerTestCase.php
@@ -175,4 +175,9 @@ class Doctrine_Manager_TestCase extends Doctrine_UnitTestCase {
     }
     public function prepareData() { }
     public function prepareTables() { }
+
+    public function testGetConnectionDrivers()
+    {
+        $this->assertTrue(is_array($this->manager->getConnectionDrivers()));
+    }
 }


### PR DESCRIPTION
With the goal to extends connections classes the method to fetch all connection drivers is expected to work.

But currently there is a typo on the property name used.