### PR TITLE
Fix connection binding to component for all autoloaded models

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,8 @@ matrix:
     - php: nightly
     - php: hhvm
 
+before_script:
+  - composer install
+
 script:
   - php -dshort_open_tag=Off -dmagic_quotes_gpc=Off tests/index.php

--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,8 @@
     },
     "autoload": {
         "psr-0": { "Doctrine_": "lib/" }
+    },
+    "autoload-dev": {
+        "psr-4": { "": "tests/autoloaded/" }
     }
 }

--- a/lib/Doctrine/Manager.php
+++ b/lib/Doctrine/Manager.php
@@ -552,9 +552,7 @@ class Doctrine_Manager extends Doctrine_Configurable implements Countable, Itera
      */
     public function getConnectionForComponent($componentName)
     {
-        Doctrine_Core::modelsAutoload($componentName);
-
-        if (isset($this->_bound[$componentName])) {
+        if ($this->hasConnectionForComponent($componentName)) {
             return $this->getConnection($this->_bound[$componentName]);
         }
 
@@ -569,6 +567,10 @@ class Doctrine_Manager extends Doctrine_Configurable implements Countable, Itera
      */
     public function hasConnectionForComponent($componentName = null)
     {
+        if (!Doctrine_Core::modelsAutoload($componentName)) {
+            class_exists($componentName); // Trigger autoloader to bind connection.
+        }
+
         return isset($this->_bound[$componentName]);
     }
 

--- a/tests/autoloaded/ModelBindConnection.php
+++ b/tests/autoloaded/ModelBindConnection.php
@@ -1,0 +1,11 @@
+<?php
+
+Doctrine_Manager::getInstance()->bindComponent('ModelBindConnection', 'test_bind_connection');
+
+class ModelBindConnection extends Doctrine_Record
+{
+    public function setTableDefinition()
+    {
+        $this->hasColumn('name', 'string', 1);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,7 +12,7 @@ ini_set('date.timezone', 'GMT+0');
 
 define('DOCTRINE_DIR', $_SERVER['DOCTRINE_DIR']);
 
-require_once(DOCTRINE_DIR . '/lib/Doctrine/Core.php');
+require_once DOCTRINE_DIR.'/vendor/autoload.php';
 
 spl_autoload_register(array('Doctrine_Core', 'autoload'));
 spl_autoload_register(array('Doctrine_Core', 'modelsAutoload'));


### PR DESCRIPTION
Patch for more than one master connection.

Modern and symfony1 applications do not use `Doctrine_Core::loadModels()` even conservative or aggressive mode.

For such setup models that are bound to a specific connection are attached to the current connection instead of the bound one.

After some deeper investigations for the query factory the connection is set on the flow (`_passedConn === false`):
* on create set the current connection
* call `preQuery()` (usage like on `sfDoctrineMasterSlavePlugin` get the current connection)
* on build SQL query (just before execution) it sets the query connection for each components (I do not see any check when at least two components use different connection)
