### PR TITLE
[8.x Compatibility] Doctrine_Validator::validateLength - Deprecation

### DIFF
--- a/lib/Doctrine/Validator.php
+++ b/lib/Doctrine/Validator.php
@@ -89,7 +89,7 @@ class Doctrine_Validator extends Doctrine_Locator_Injectable
      */
     public static function validateLength($value, $type, $maximumLength)
     {
-        if ($maximumLength === null ) {
+        if ($maximumLength === null || $value === null) {
             return true;
         }
         if ($type == 'timestamp' || $type == 'integer' || $type == 'enum') {


### PR DESCRIPTION
If a model definition contains a column of type decimal that allows nullable values, Doctrine_Table attempts to [validate the length of the null value](https://github.com/FriendsOfSymfony1/doctrine1/blob/0978095bf51d95a8875df705c590a21363cec797/lib/Doctrine/Table.php#L2127), which calls [Doctrine_Validator::validateLength](https://github.com/FriendsOfSymfony1/doctrine1/blob/0978095bf51d95a8875df705c590a21363cec797/lib/Doctrine/Validator.php#L90) and ultimately throws a deprecation notice when it [tries to call `abs()` on the null value](https://github.com/FriendsOfSymfony1/doctrine1/blob/0978095bf51d95a8875df705c590a21363cec797/lib/Doctrine/Validator.php#L100).

> PHP message: PHP Deprecated:  abs(): Passing null to parameter #1 ($num) of type int|float is deprecated in /path/to/friendsofsymfony1/doctrine1/lib/Doctrine/Validator.php on line 100

This PR simply returns `true` early if the $value is `null`, which is what it would return anyway.