### PR TITLE
Reactivating coverage

### DIFF
--- a/tests/DoctrineTest/Coverage.php
+++ b/tests/DoctrineTest/Coverage.php
@@ -140,7 +140,8 @@ class DoctrineTest_Coverage
      */
     public function generateReport()
     {
-        $svn_info = explode(" ", exec("svn info | grep Revision"));
+        // $svn_info = explode(" ", exec("svn info | grep Revision"));
+        $svn_info = 'svn is not used anymore. maybe adding some git infos or drop it?';
         $this->result["revision"] = $svn_info[1];
 
         //loop through all files and generate coverage files for them

--- a/tests/DoctrineTest/Coverage.php
+++ b/tests/DoctrineTest/Coverage.php
@@ -115,11 +115,14 @@ class DoctrineTest_Coverage
     /**
      * Return the revision the coverage was made against
      *
-     *@param int The revision number
+     * @return int The revision number
+     * @deprecated Coverage revision is not supported anymore.
      */
     public function getRevision()
     {
-        return $this->result["revision"];
+        trigger_error('Coverage revision is not supported anymore.', E_USER_DEPRECATED);
+
+        return 0;
     }
 
     /**
@@ -140,10 +143,6 @@ class DoctrineTest_Coverage
      */
     public function generateReport()
     {
-        // $svn_info = explode(" ", exec("svn info | grep Revision"));
-        $svn_info = 'svn is not used anymore. maybe adding some git infos or drop it?';
-        $this->result["revision"] = $svn_info[1];
-
         //loop through all files and generate coverage files for them
         $it = new RecursiveDirectoryIterator(Doctrine_Core::getPath());
         $notCoveredArray = array();

--- a/tests/DoctrineTest/Coverage.php
+++ b/tests/DoctrineTest/Coverage.php
@@ -46,6 +46,8 @@ class DoctrineTest_Coverage
     private $totalnotcovered = 0;
     private $result;
 
+    public $sortBy;
+
     /*
      * Create a new Coverage object. We read data from a fixed file. 
      */

--- a/tests/DoctrineTest/Coverage.php
+++ b/tests/DoctrineTest/Coverage.php
@@ -163,6 +163,10 @@ class DoctrineTest_Coverage
                 continue;
             }
 
+            if (strpos($class, 'sfYaml')) {
+                continue;
+            }
+
             if ( ! class_exists($class)) {
                 continue;
             }


### PR DESCRIPTION
This three steps are the minimum to get coverage working again. It can be used by invoking `php run.php --coverage` and will write the results in tests/coverage/*