### PR TITLE
Fix Mysql.php constructor annotations, use Doctrine_Adapter_Interface

### DIFF
--- a/lib/Doctrine/Connection/Mysql.php
+++ b/lib/Doctrine/Connection/Mysql.php
@@ -42,7 +42,7 @@ class Doctrine_Connection_Mysql extends Doctrine_Connection_Common
      * the constructor
      *
      * @param Doctrine_Manager $manager
-     * @param PDO|Doctrine_Adapter $adapter     database handler
+     * @param PDO|Doctrine_Adapter_Interface $adapter     database handler
      */
     public function __construct(Doctrine_Manager $manager, $adapter)
     {


### PR DESCRIPTION
Existing constructor phpdoc references Doctrine_Adapter, which doesn't appear to exist. 
Parent class (Doctrine_Connection) already references Doctrine_Adapter_Interface.